### PR TITLE
Fix for compatibility with weechat

### DIFF
--- a/lib/flamethrower/connection.rb
+++ b/lib/flamethrower/connection.rb
@@ -11,6 +11,7 @@ module Flamethrower
     end
 
     def after_connect
+      send_welcome
       send_motd
       populate_irc_channels
       populate_my_user

--- a/lib/flamethrower/dispatcher.rb
+++ b/lib/flamethrower/dispatcher.rb
@@ -81,6 +81,7 @@ module Flamethrower
         channel.users << connection.current_user
         room.join
         room.start
+        connection.send_join(connection.current_user, channel)
       end
     end
 

--- a/lib/flamethrower/irc/codes.rb
+++ b/lib/flamethrower/irc/codes.rb
@@ -1,6 +1,7 @@
 module Flamethrower
   module Irc
     module Codes
+      RPL_WLCM = '001'
       RPL_UMODEIS = 221
       RPL_UNAWAY = 305
       RPL_NOWAWAY = 306

--- a/lib/flamethrower/irc/commands.rb
+++ b/lib/flamethrower/irc/commands.rb
@@ -3,10 +3,13 @@ module Flamethrower
     module Commands
       include Flamethrower::Irc::Codes
 
+      def send_welcome
+        send_message reply(RPL_WLCM, ":Welcome to Flamethrower")
+      end
+
       def send_motd
         send_messages do |messages|
           messages << reply(RPL_MOTDSTART, ":MOTD")
-          messages << reply(RPL_MOTD, ":Welcome to Flamethrower")
           messages << reply(RPL_MOTD, ":Fetching channel list from campfire...")
         end
       end
@@ -64,6 +67,10 @@ module Flamethrower
 
       def send_user_mode
         send_message reply(RPL_UMODEIS, @current_user.mode)
+      end
+
+      def send_join(user, channel)
+        send_message ":#{user.to_s} JOIN #{channel.name}"
       end
 
       def send_part(user, channel)

--- a/spec/unit/connection_spec.rb
+++ b/spec/unit/connection_spec.rb
@@ -53,6 +53,13 @@ describe Flamethrower::Connection do
         to_return(:status => 200, :body => json_fixture("rooms"))
     end
 
+    it "sends welcome" do
+      @connection.stub(:populate_irc_channels)
+      @connection.stub(:populate_my_user)
+      @connection.should_receive(:send_welcome)
+      @connection.after_connect
+    end
+
     it "sends motd" do
       @connection.stub(:populate_irc_channels)
       @connection.stub(:populate_my_user)
@@ -82,10 +89,13 @@ describe Flamethrower::Connection do
   end
 
   describe "IRCcommands" do
+    it "should have a first message" do
+      @connection.send_welcome.should == ":host 001 nick :Welcome to Flamethrower"
+    end
+
     it "should have the correct MOTD format" do
       @connection.send_motd.should == [
         ":host 375 nick :MOTD",
-        ":host 372 nick :Welcome to Flamethrower",
         ":host 372 nick :Fetching channel list from campfire..."
       ]
     end

--- a/spec/unit/dispatcher_spec.rb
+++ b/spec/unit/dispatcher_spec.rb
@@ -254,6 +254,15 @@ describe Flamethrower::Dispatcher do
       @dispatcher.handle_message(message)
     end
 
+    it "sends a join message with your current user's name" do
+      EventMachine.stub(:cancel_timer)
+      user = Flamethrower::Irc::User.new :username => "user", :nickname => "nick", :hostname => "host", :realname => "realname", :servername => "servername"
+      @connection.current_user = user
+      message = Flamethrower::Irc::Message.new("JOIN #flamethrower")
+      @connection.should_receive(:send_message).with(":#{user.to_s} JOIN #flamethrower")
+      @dispatcher.handle_message(message)
+    end
+
     it "sends a join command to the API" do
       message = Flamethrower::Irc::Message.new("JOIN #flamethrower\r\n")
       @room.should_receive(:join)


### PR DESCRIPTION
Hi!

When connecting to flamethrower with weechat, weechat would disconnect after a minute because it never received a message 001 from flamethrower.  Also, you couldn't join a room in weechat because flamethrower didn't send a JOIN #room_name message (like it does for PARTs).

I have added these capabilities. I also added tests for them however I wasn't able to actually run them. :(  EventMachine was seg faulting on my machine (Ubuntu 11.10) and apparently this is a known issue. I hope the tests work but let me know if they don't and I'll spin up a Ubuntu 11.04 box and fix them.
- When a client connects a first message (001) should be sent
- When joining a room, the server should send back a JOIN #room_name
  message
