### PR TITLE
Update Gemfile source to https://rubygems.org

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source :gemcutter
+source 'https://rubygems.org'
 
 gem 'eventmachine'
 gem 'twitter-stream'


### PR DESCRIPTION
In the Gemfile, `source :gemcutter` is deprecated and now throws
warnings when using Bundler.  This commit updates the Gemfile source to
the recommended 'https://rubygems.org', which provides a more secure
gem source and resolves the warnings.
